### PR TITLE
Add codeclimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,3 @@
+plugins:
+  cppcheck:
+    enabled: true


### PR DESCRIPTION
We're using codeclimate for our linting with its cppcheck plugin. This
config lets it know to use the plugin.